### PR TITLE
Disabled BT MAP causing cyclic BT reconnect

### DIFF
--- a/aosp_rpi4_car.mk
+++ b/aosp_rpi4_car.mk
@@ -28,6 +28,7 @@ PRODUCT_VENDOR_PROPERTIES += \
     bluetooth.profile.hfp.ag.enabled=false \
     bluetooth.profile.hid.device.enabled=false \
     bluetooth.profile.hid.host.enabled=false \
+    bluetooth.profile.map.client.enabled=false \
     bluetooth.profile.map.server.enabled=false \
     bluetooth.profile.mcp.server.enabled=false \
     bluetooth.profile.opp.enabled=false \

--- a/aosp_rpi4_car.mk
+++ b/aosp_rpi4_car.mk
@@ -18,7 +18,6 @@ PRODUCT_VENDOR_PROPERTIES += \
     bluetooth.device.class_of_device=38,4,8 \
     bluetooth.profile.a2dp.source.enabled=false \
     bluetooth.profile.asha.central.enabled=false \
-    bluetooth.profile.avrcp.target.enabled=false \
     bluetooth.profile.bap.broadcast.assist.enabled=false \
     bluetooth.profile.bap.unicast.client.enabled=false \
     bluetooth.profile.bas.client.enabled=false \


### PR DESCRIPTION
 - Disabled BT Message Access Profile. Allows to keep connection to the paired device
 - Enabled AVRCP target. It fixes immediate playback stop while the phone is connected to the RPi and media is started to play.