### PR TITLE
selinux: fix boot blocking denials for graphics composer and usb gadget

### DIFF
--- a/sepolicy/hal_graphics_composer_default.te
+++ b/sepolicy/hal_graphics_composer_default.te
@@ -3,3 +3,4 @@ gpu_access(hal_graphics_composer_default)
 get_prop(hal_graphics_composer_default, vendor_hwc_config_prop)
 
 allow hal_graphics_composer_default self:netlink_kobject_uevent_socket { bind create read };
+hal_client_domain(hal_graphics_composer_default, hal_graphics_allocator);

--- a/sepolicy/hal_usb_gadget_default.te
+++ b/sepolicy/hal_usb_gadget_default.te
@@ -1,0 +1,1 @@
+allow hal_usb_gadget_default functionfs:dir { watch watch_reads };


### PR DESCRIPTION
* When SELinux is enforcing, the device fails to boot due to denials related to hal_graphics_composer_default. ADB connection is also unavailable because of denials from hal_usb_gadget_default.
* Add the required SELinux rules to allow the affected HAL services to start correctly.